### PR TITLE
Secure GoatCounter script with SRI and version pinning

### DIFF
--- a/blank.html
+++ b/blank.html
@@ -14,7 +14,7 @@
     <!-- <link type="application/atom+xml" rel="alternate" href="/feed.xml" title="Title">-->
     <!--<RSS Feed for your site.> -->
 
-    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="https://gc.zgo.at/count.v5.js" crossorigin="anonymous" integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ"></script>
 
     <script type="module">
         document.documentElement.classList.remove('no-js');

--- a/blog/2022-11-24/signal.html
+++ b/blog/2022-11-24/signal.html
@@ -14,7 +14,7 @@
     <!-- <link type="application/atom+xml" rel="alternate" href="/feed.xml" title="Title">-->
     <!--<RSS Feed for your site.> -->
 
-    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="https://gc.zgo.at/count.v5.js" crossorigin="anonymous" integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ"></script>
 
     <script type="module">
         document.documentElement.classList.remove('no-js');

--- a/blog/blog-template.html
+++ b/blog/blog-template.html
@@ -14,7 +14,7 @@
     <!-- <link type="application/atom+xml" rel="alternate" href="/feed.xml" title="Title">-->
     <!--<RSS Feed for your site.> -->
 
-    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="https://gc.zgo.at/count.v5.js" crossorigin="anonymous" integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ"></script>
 
     <script type="module">
         document.documentElement.classList.remove('no-js');

--- a/blog/index.html
+++ b/blog/index.html
@@ -15,7 +15,7 @@
     <!--<RSS Feed for your site.> -->
     <script defer data-domain="malcolmdsmith.com" src="https://plausible.io/js/plausible.js"></script>
 
-    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="https://gc.zgo.at/count.v5.js" crossorigin="anonymous" integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ"></script>
 
     <script type="module">
         document.documentElement.classList.remove('no-js');

--- a/contact.html
+++ b/contact.html
@@ -14,7 +14,7 @@
     <!-- <link type="application/atom+xml" rel="alternate" href="/feed.xml" title="Title">-->
     <!--<RSS Feed for your site.> -->
 
-    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="https://gc.zgo.at/count.v5.js" crossorigin="anonymous" integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ"></script>
 
     <script type="module">
         document.documentElement.classList.remove('no-js');

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <!-- <link type="application/atom+xml" rel="alternate" href="/feed.xml" title="Title">-->
     <!--<RSS Feed for your site.> -->
 
-    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="https://gc.zgo.at/count.v5.js" crossorigin="anonymous" integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ"></script>
 
     <script type="module">
         document.documentElement.classList.remove('no-js');

--- a/kimberly/kgs-index.html
+++ b/kimberly/kgs-index.html
@@ -14,8 +14,7 @@
     <!-- <link type="application/atom+xml" rel="alternate" href="/feed.xml" title="Title">-->
     <!--<RSS Feed for your site.> -->
 
-    <script data-goatcounter="https://mds08011.goatcounter.com/count"
-        async src="//gc.zgo.at/count.js"></script>
+    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="https://gc.zgo.at/count.v5.js" crossorigin="anonymous" integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ"></script>
 
     <script type="module">
         document.documentElement.classList.remove('no-js');

--- a/online/index.html
+++ b/online/index.html
@@ -13,7 +13,7 @@
     <!-- <link type="application/atom+xml" rel="alternate" href="/feed.xml" title="Title">-->
     <!--<RSS Feed for your site.> -->
 
-    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="https://gc.zgo.at/count.v5.js" crossorigin="anonymous" integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ"></script>
 
 
     <script type="module">

--- a/online/piracy.html
+++ b/online/piracy.html
@@ -13,8 +13,7 @@
     <!-- <Print CSS for the site.> -->
     <!-- <link type="application/atom+xml" rel="alternate" href="/feed.xml" title="Title">-->
     <!--<RSS Feed for your site.> -->
-        <script data-goatcounter="https://mds08011.goatcounter.com/count"
-        async src="//gc.zgo.at/count.js"></script>
+        <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="https://gc.zgo.at/count.v5.js" crossorigin="anonymous" integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ"></script>
 
     <script type="module">
         document.documentElement.classList.remove('no-js');

--- a/online/web-dev.html
+++ b/online/web-dev.html
@@ -13,7 +13,7 @@
     <!-- <Print CSS for the site.> -->
     <!-- <link type="application/atom+xml" rel="alternate" href="/feed.xml" title="Title">-->
     <!--<RSS Feed for your site.> -->
-    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="https://gc.zgo.at/count.v5.js" crossorigin="anonymous" integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ"></script>
 
 
     <script type="module">

--- a/osm/openstreetmap.html
+++ b/osm/openstreetmap.html
@@ -14,7 +14,7 @@
     <!-- <link type="application/atom+xml" rel="alternate" href="/feed.xml" title="Title">-->
     <!--<RSS Feed for your site.> -->
 
-    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <script data-goatcounter="https://mds08011.goatcounter.com/count" async src="https://gc.zgo.at/count.v5.js" crossorigin="anonymous" integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ"></script>
 
 
     <script type="module">


### PR DESCRIPTION
Replaces the deprecated protocol-relative URL for `count.js` with the secure, versioned `https://gc.zgo.at/count.v5.js` URL.
Adds Subresource Integrity (SRI) hash to ensure the script has not been tampered with.
Updates all occurrences across the site.

---
*PR created automatically by Jules for task [13923872369589384601](https://jules.google.com/task/13923872369589384601) started by @mds08011*